### PR TITLE
add option to overwrite a previous atlas import

### DIFF
--- a/src/main/java/qupath/ext/biop/abba/LoadAtlasRoisToQuPathCommand.java
+++ b/src/main/java/qupath/ext/biop/abba/LoadAtlasRoisToQuPathCommand.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import qupath.ext.biop.abba.struct.AtlasHelper;
 import qupath.ext.biop.abba.struct.AtlasOntology;
 import qupath.lib.gui.QuPathGUI;
-import qupath.lib.gui.dialogs.Dialogs;
+import qupath.fx.dialogs.Dialogs;
 import qupath.lib.images.ImageData;
 import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 import qupath.lib.plugins.workflow.WorkflowStep;
@@ -52,7 +52,7 @@ public class LoadAtlasRoisToQuPathCommand implements Runnable {
         if (doRun) {
             ImageData<BufferedImage> imageData = qupath.getImageData();
             List<String> atlasNames = AtlasTools.getAvailableAtlasRegistration(imageData);
-            if (atlasNames.size()==0) {
+            if (atlasNames.isEmpty()) {
                 Dialogs.showErrorMessage("No atlas registration found.", "You need to export your registration from Fiji's ABBA plugin.");
                 logger.error("No atlas registration found."); // TODO : show an error message for the user
                 return;
@@ -76,10 +76,10 @@ public class LoadAtlasRoisToQuPathCommand implements Runnable {
             ontology.setNamingProperty(namingProperty);
 
             // Now we have all we need, the name whether to split left and right
-            AtlasTools.loadWarpedAtlasAnnotations(ontology, imageData, atlasName, splitLeftRight);
+            AtlasTools.loadWarpedAtlasAnnotations(ontology, imageData, splitLeftRight, true);
 
             // Add a step to the workflow
-            String method = AtlasTools.class.getName()+".loadWarpedAtlasAnnotations(getCurrentImageData(), \""+namingProperty+"\", "+splitLeftRight+");";
+            String method = AtlasTools.class.getName()+".loadWarpedAtlasAnnotations(getCurrentImageData(), \""+namingProperty+"\", "+splitLeftRight+", true);";
             WorkflowStep newStep = new DefaultScriptableWorkflowStep("Load Brain RoiSets into Image", method);
             imageData.getHistoryWorkflow().addStep(newStep);
         }

--- a/src/main/resources/scripts/Compute_cell_centroid_atlas_coordinates.groovy
+++ b/src/main/resources/scripts/Compute_cell_centroid_atlas_coordinates.groovy
@@ -24,9 +24,9 @@ getDetectionObjects().forEach(detection -> {
     MeasurementList ml = detection.getMeasurementList();
     atlasCoordinates.setPosition([detection.getROI().getCentroidX(),detection.getROI().getCentroidY(),0] as double[]);
     pixelToAtlasTransform.apply(atlasCoordinates, atlasCoordinates);
-    ml.putMeasurement("Atlas_X", atlasCoordinates.getDoublePosition(0) )
-    ml.putMeasurement("Atlas_Y", atlasCoordinates.getDoublePosition(1) )
-    ml.putMeasurement("Atlas_Z", atlasCoordinates.getDoublePosition(2) )
+    ml.put("Axis_X", atlasCoordinates.getDoublePosition(0));
+    ml.put("Axis_Y", atlasCoordinates.getDoublePosition(1));
+    ml.put("Axis_Z", atlasCoordinates.getDoublePosition(2));
 })
 
 import qupath.ext.warpy.Warpy

--- a/src/main/resources/scripts/example_manipulate_atlas_annotations.groovy
+++ b/src/main/resources/scripts/example_manipulate_atlas_annotations.groovy
@@ -7,8 +7,6 @@
  *  - have exported the registration result of the image in ABBA (in Fiji)
  *  - have some cells already detected on this opened image
  *
- * TODO : Display a warning message if several atlases are found (Allen v3 and Allen v3.1)	
- *
  * This script is not supposed to work in one block. Just copy paste in another script the parts you need
  */
 
@@ -23,12 +21,15 @@ removeObjects(getAnnotationObjects(), false) // last argument = keep child objec
 
 // 3. To import the atlas regions (take care to not import it several times: clear the objects before)
 // Load atlas and name all regions according with their acronym
-// Last argument = split left and right regions
-qupath.ext.biop.abba.AtlasTools.loadWarpedAtlasAnnotations(getCurrentImageData(), "acronym", true);
+// Last two arguments:
+//   * split left and right regions
+//   * overwrite the previously imported atlas annotations, if present and new and old atlas versions match
+def atlasRoot = qupath.ext.biop.abba.AtlasTools.loadWarpedAtlasAnnotations(getCurrentImageData(), "acronym", true, true);
+def allRegions = atlasRoot.getDescendantObjects(null)
 
 // 4. To collect and select a subregion (here the only with the acronym ‘CTXpl’)
 // Gets all annotations (=regions) named CTXpl (left and right)
-def myObjects = getAllObjects().findAll{it.getName() == 'CTXpl'} // replace 'CTXpl' by any region acronym existing in the atlas
+def myObjects = allRegions.findAll{it.getName() == 'CTXpl'} // replace 'CTXpl' by any region acronym existing in the atlas
 
 // Then select them
 selectObjects(myObjects)
@@ -36,11 +37,11 @@ selectObjects(myObjects)
 // 5. same as 4., but restricting to the left part of the brain
 
 // Gets all annotations named CTXpl in the left region:
-def myLeftObjects = getAnnotationObjects()
+def myLeftObjects = allRegions
                 .findAll{it.getName() == 'CTXpl'} // replace 'CTXpl' by any region acronym existing in the atlas
                 .findAll{it.getPathClass().isDerivedFrom(getPathClass('Left'))} // select only the ones in the left regions
 
-// Then select them      
+// Then select them
 selectObjects(myLeftObjects)
 
 // 6. to collect and select subregions from a list
@@ -49,18 +50,18 @@ selectObjects(myLeftObjects)
 listOfRegionsToSelect=['MPN', 'CTXsp', 'ACAd']
 
 
-def myObjectsWithinAList = getAnnotationObjects()
+def myObjectsWithinAList = allRegions
                 .findAll{it.getName() in listOfRegionsToSelect}
                 //.findAll{it.getPathClass().isDerivedFrom(getPathClass('Left'))} // Uncomment this line to get only the objects in the left region
 
-// Then select them             
+// Then select them
 selectObjects(myObjectsWithinAList)
 
 // 7. to collect all regions except the ones on a list
 
-def myObjectsWithinAList = getAnnotationObjects()
+def myObjectsWithinAList = allRegions
                 .findAll{!(it.getPathClass() == null)} // removes null objects
-                .findAll{it.getPathClass().isDerivedFrom(getPathClass('Left'))} 
+                .findAll{it.getPathClass().isDerivedFrom(getPathClass('Left'))}
 
 // Gets all annotations except the ones of a list
 def objectsOtherThan = getAnnotationObjects() - myObjectsWithinAList


### PR DESCRIPTION
With this PR:
* the `Root` annotation is now classified by the corresponding atlas version name
* the `Root` annotation is locked
* if a previous atlas import was modified but its hierarchy is not disrupted (i.e. everything is still a child of `Root`), it can be re-imported without resulting in duplicate annotations
* removes the `atlasName` from some API calls when the onthology is passed too. May be breaking, but it is redundant and misleading
* fixes some deprecated calls
* renames an example script