### PR TITLE
removed dependency on QuPathGUI

### DIFF
--- a/src/main/java/qupath/ext/biop/abba/AtlasImporter.java
+++ b/src/main/java/qupath/ext/biop/abba/AtlasImporter.java
@@ -55,7 +55,7 @@ public class AtlasImporter {
     private AtlasOntology ontology;
 
     public AtlasImporter(ImageData<BufferedImage> imageData) {
-        this.project = qupath.getProject();
+        this.project = QP.getProject();
         this.imageData = imageData;
     }
 
@@ -73,8 +73,6 @@ public class AtlasImporter {
     }
 
     final static Logger logger = LoggerFactory.getLogger(AtlasImporter.class);
-
-    private static final QuPathGUI qupath = QuPathGUI.getInstance();
 
     public static class AtlasBuilder {
         private ImageData<BufferedImage> imageData;
@@ -491,11 +489,11 @@ public class AtlasImporter {
     }
 
     private File getEntryFolder( ImageData<BufferedImage> imageData ) {
-        return qupath.getProject().getEntry(imageData).getEntryPath().toFile();
+        return QP.getProject().getEntry(imageData).getEntryPath().toFile();
     }
 
     private File getProjectFolder( ImageData<BufferedImage> imageData ) {
-        return new File( qupath.getProject().getPath().toFile().getParent() );
+        return new File( QP.getProject().getPath().toFile().getParent() );
     }
 
 

--- a/src/main/java/qupath/ext/biop/abba/AtlasTools.java
+++ b/src/main/java/qupath/ext/biop/abba/AtlasTools.java
@@ -52,8 +52,6 @@ public class AtlasTools {
 
     final static Logger logger = LoggerFactory.getLogger(AtlasTools.class);
 
-    private static final QuPathGUI qupath = QuPathGUI.getInstance();
-
     static private PathObject createAnnotationHierarchy(List<PathObject> annotations) {
 
         // Map the ID of the annotation to ease finding parents
@@ -128,7 +126,7 @@ public class AtlasTools {
     }
 
     public static List<PathObject> getFlattenedWarpedAtlasRegions(AtlasOntology ontology, ImageData<BufferedImage> imageData, boolean splitLeftRight) {
-        Project<BufferedImage> project = qupath.getProject();
+        Project<BufferedImage> project = QP.getProject();
 
         // Loop through each ImageEntry
         ProjectImageEntry<BufferedImage> entry = project.getEntry(imageData);
@@ -318,7 +316,7 @@ public class AtlasTools {
     }
 
     public static List<String> getAvailableAtlasRegistration(ImageData<BufferedImage> imageData) {
-        Project<BufferedImage> project = qupath.getProject();
+        Project<BufferedImage> project = QP.getProject();
         ProjectImageEntry<BufferedImage> entry = project.getEntry(imageData);
 
         List<String> atlasNames = new ArrayList<>();
@@ -348,7 +346,7 @@ public class AtlasTools {
     }
 
     public static RealTransform getAtlasToPixelTransform(ImageData<BufferedImage> imageData, String atlasName) {
-        Project<BufferedImage> project = qupath.getProject();
+        Project<BufferedImage> project = QP.getProject();
         ProjectImageEntry<BufferedImage> entry = project.getEntry(imageData);
         File fTransform = new File(entry.getEntryPath().toString(),"ABBA-Transform-"+atlasName+".json");
         if (!fTransform.exists()) {
@@ -421,7 +419,7 @@ public class AtlasTools {
             logger.warn("Several atlases registration have been found. Importing atlas: "+atlasName);
         }
 
-        Path ontologyPath = Paths.get(Projects.getBaseDirectory(qupath.getProject()).getAbsolutePath(), atlasName+"-Ontology.json");
+        Path ontologyPath = Paths.get(Projects.getBaseDirectory(QP.getProject()).getAbsolutePath(), atlasName+"-Ontology.json");
         AtlasOntology ontology = AtlasHelper.openOntologyFromJsonFile(ontologyPath.toString());
 
         if (ontology == null) {


### PR DESCRIPTION
This allows the ABBA extension to be used with QuPath CLI and [paquo](https://paquo.readthedocs.io/).

Just remember to first call `QP.setBatchProjectAndImage(project, imageData)`, if outside of a QuPath GUI 